### PR TITLE
Removed `--ignore vertx` in browserify scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",
-    "build": "browserify --ignore vertx -t brfs . -o bundle.js",
-    "watch": "watchify --ignore vertx -t brfs -d . -o bundle.js"
+    "build": "browserify -t brfs . -o bundle.js",
+    "watch": "watchify -t brfs -d . -o bundle.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You might need to update your deps for this to work.

https://github.com/tildeio/rsvp.js/pull/366
