### PR TITLE
update virtualdom state renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "random-uuid-v4": "0.0.4",
     "riot": "^2.0.11",
     "riot-state-renderer": "^4.0.0",
-    "virtualdom-state-renderer": "0.0.1"
+    "virtualdom-state-renderer": "0.1.0"
   },
   "devDependencies": {
     "brfs": "^1.3.0",


### PR DESCRIPTION
Updated `virtualdom-state-renderer` from `0.0.1` to `0.1.0`.

(The `virtualdom-state-renderer` update probably should've bumped the patch version, not the minor version, because there were not breaking changes that I know of.)
